### PR TITLE
Fix deprecation warning of datetime utcnow()

### DIFF
--- a/ojp_performance_tests.py
+++ b/ojp_performance_tests.py
@@ -7,6 +7,7 @@ See: https://github.com/openTdataCH/ojpch-performance-test
 """
 
 import csv
+import datetime
 import json
 import logging
 import math
@@ -17,12 +18,11 @@ import statistics
 import sys
 import time
 import xml.dom.minidom
-import datetime
-from utilities.template_util import Template
 
 import requests
 
 import configuration as config
+from utilities.template_util import Template
 
 # global variables:
 didoklist = []

--- a/ojp_performance_tests.py
+++ b/ojp_performance_tests.py
@@ -35,15 +35,25 @@ par_dict = {}
 connections = None
 didok_for_places = None
 
-# logging to console and/or to file: - comment-out those lines not needed:
-LOG_FILE = './output/latest_log.log'
-LOG_HANDLERS = [
-    logging.StreamHandler(sys.stdout),
-    # logging.FileHandler(LOG_FILE, 'w', 'utf-8'),
-]
-logging.basicConfig(handlers=LOG_HANDLERS, level=logging.INFO, format='%(asctime)s: %(levelname)s: %(message)s')
 
+# constants:
 NA = 'n/a'
+LOG_FILE = os.path.join(config.OUTPUT, 'latest_log.txt')
+
+
+def prepare_directories():
+    for dir in (config.OUTPUT, config.DATA):
+        if not os.path.exists(dir):
+            os.mkdir(dir)
+
+
+def prepare_logging():
+    # logging to console (stdout) and/or to file: - comment-out those lines not needed in a given setup:
+    log_handlers = [
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler(LOG_FILE, 'w', 'utf-8'),
+    ]
+    logging.basicConfig(handlers=log_handlers, level=logging.INFO, format='%(asctime)s: %(levelname)s: %(message)s')
 
 
 def load_parameters():
@@ -94,12 +104,6 @@ def load_didok():
             if 'ch:1:sloid' in row[0]:
                 didoklist.append(row)
     logging.info(f"Loaded {len(didoklist)} stations/stops from DIDOK file {config.DIDOK_FILE}.")
-
-
-def prepare_directories():
-    for dir in (config.OUTPUT, config.DATA):
-        if not os.path.exists(dir):
-            os.mkdir(dir)
 
 
 def remove_old_test_directories():
@@ -495,13 +499,15 @@ def save_statistics(stats: list, test_directory: str):
 
 
 def copy_log_file(test_directory):
-    shutil.copy2(LOG_FILE, os.path.join(config.OUTPUT, test_directory, '_log.txt'))
+    if os.path.exists(LOG_FILE):
+        shutil.copy2(LOG_FILE, os.path.join(config.OUTPUT, test_directory, '_log.txt'))
 
 
 def process():
+    prepare_directories()
+    prepare_logging()
     parameter_file = load_parameters()
     set_random_seed()
-    prepare_directories()
     load_didok()
     load_connections_file()
     stats = []

--- a/utilities/template_util.py
+++ b/utilities/template_util.py
@@ -1,14 +1,19 @@
 """Provides a class for handling templates such as XML files or XML fragments with placeholders.
 Loads a file matching the given name (without extension).
 
-Im no template folder is provided, the folder 'templates' will be used as default.
+If no template folder is provided, the folder 'templates' will be used by default.
 
-Usage example: t = Template('template_name') ; t.replace('ph1', 123).replace('ph2', 'abc') ; print(t) ;"""
+Usage example:
+t = Template('template_name')
+t.replace('ph1', 123).replace('ph2', 'abc')
+print(t)
+
+"""
 
 import os
 
-class Template:
 
+class Template:
     PH_PREFIX, PH_SUFFIX = '${', '}'
     DEFAULT_TEMPLATES_FOLDER = 'templates'
 


### PR DESCRIPTION
Fix deprecation warning of datetime utcnow()
Fix for deprecation warning "DeprecationWarning: datetime.datetime.utcnow() is deprecated".
(Used wrong account for the commit, apologies)